### PR TITLE
Fixes edge cases in Windows

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -55,7 +55,7 @@ func (c *Client) Download(ctx context.Context, operatingSystem string, arch stri
 	}
 
 	if resp.ContentLength <= 0 {
-		return errors.New("invalid content length")
+		return ErrInvalidContentLength
 	}
 
 	if err := fs.Write(
@@ -70,7 +70,6 @@ func (c *Client) Download(ctx context.Context, operatingSystem string, arch stri
 	}
 
 	return nil
-
 }
 
 func getName(os string, arch string) string {
@@ -130,6 +129,7 @@ func (c *Client) GetLatestVersion(ctx context.Context) (string, error) {
 }
 
 var ErrHTTP = errors.New("failed to get the resource")
+var ErrInvalidContentLength = errors.New("invalid content length")
 
 type release struct {
 	TagName string `json:"tag_name"`

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -30,6 +30,7 @@ func Write(
 	}
 
 	tmp := cleanPath + ".tmp"
+	//nolint:gosec // path is validated to be within downloadDir
 	f, err := os.Create(tmp)
 	if err != nil {
 		return err
@@ -44,7 +45,7 @@ func Write(
 	}
 	if written != expected {
 		_ = os.Remove(tmp)
-		return errors.New("incomplete download")
+		return ErrIncompleteDownload
 	}
 	if err := os.Rename(tmp, cleanPath); err != nil {
 		_ = os.Remove(tmp)
@@ -67,6 +68,7 @@ func Exists(path string) error {
 var ErrFileNotExists = errors.New("file does not exist")
 var ErrNotInstalled = errors.New("tailwindcss is not currently installed")
 var ErrInvalidPath = errors.New("invalid path: attempting to write outside cache directory")
+var ErrIncompleteDownload = errors.New("incomplete download")
 
 func GetCurrentVersion(path string) (string, error) {
 	entries, err := os.ReadDir(path)

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"time"
 
 	"github.com/Piszmog/go-tw/client"
 	"github.com/Piszmog/go-tw/fs"
@@ -34,7 +33,7 @@ func main() {
 		return
 	}
 
-	c := client.New(logger, 30*time.Second)
+	c := client.New(logger)
 
 	version, args, err := getArgs()
 	if err != nil {
@@ -104,7 +103,17 @@ func main() {
 			return
 		}
 	}
+	info, err := os.Stat(filePath)
+	if err != nil {
+		fmt.Println("tailwind binary missing:", err)
+		return
+	}
 
+	if info.Size() < 1024 {
+		_ = os.Remove(filePath)
+		fmt.Println("invalid tailwind binary detected, please retry")
+		return
+	}
 	if err := run(ctx, logger, filePath, args); err != nil {
 		fmt.Println("failed to run tailwind: ", err)
 	}


### PR DESCRIPTION
- Removed HTTP client timeout to prevent partial downloads of the Windows Tailwind .exe
- Switched to atomic writes with Content-Length verification to avoid caching corrupted binaries.
- Ensured failed downloads never leave an executable that can be reused it will be a .tmp file.